### PR TITLE
Biber 2.7 introduced a new bug: instead of a warning message, it outp…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ all: $(TEX_TESTS) $(PDF_TESTS)
 	@echo "--- Test of $<"
 	rm -f $(patsubst %.tex,%.aux,$<)
 	$(PDFLATEX) $<
-	$(BIBER) $(basename $<) | sed -e '/WARN - month field/d' | sed -e '/cannot be null, deleting it/d' # remove the issues with the months and the empty fields
+	$(BIBER) $(basename $<) 2>&1 | sed -e '/WARN - month field/d' | sed -e '/cannot be null, deleting it/d' |  sed -e '/line 279/d' # remove the issues with the months and the empty fields
 
 %_bibtex.pdf: %_bibtex.tex clean FORCE
 	@echo


### PR DESCRIPTION
Biber 2.7 introduced a new bug: instead of a warning message, it outputs a perl error when a field is empty.
More precisely, it outputs
```
Use of uninitialized value in lc at /var/folders/[some temp folder path]/inc/lib/Biber/Output/bbl.pm line 279.
```

See [biber's issue 174](https://github.com/plk/biber/issues/174) for more details.